### PR TITLE
Fixing issue #1 "TraceFileManager throws exceptions if flush is called

### DIFF
--- a/org.jactr.tests/src/org/jactr/tools/tracer/sinks/trace/internal/TraceFileManagerTest.java
+++ b/org.jactr.tests/src/org/jactr/tools/tracer/sinks/trace/internal/TraceFileManagerTest.java
@@ -1,0 +1,46 @@
+package org.jactr.tools.tracer.sinks.trace.internal;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.jactr.tools.tracer.transformer.ITransformedEvent;
+import org.jmock.Expectations;
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TraceFileManagerTest {
+	
+	@Rule
+	public JUnitRuleMockery context = new JUnitRuleMockery();
+	
+	@Test
+	public void mustNotThrowExceptionIfFlushIsCalledBeforeNewRecord() throws IOException {
+		
+		ITransformedEvent event = context.mock(ITransformedEvent.class);
+		
+		Expectations expectations = new Expectations() {{
+			allowing(event).getSimulationTime();
+				will(returnValue(0.0d));
+		}};
+		
+		context.checking(expectations);
+		
+		File outputDirectory = File.createTempFile("output", "dir");
+		try {
+			TraceIndex index = new TraceIndex(outputDirectory);
+			TraceFileManager manager = new TraceFileManager(outputDirectory, index);
+			manager.flush();
+			manager.record(event);
+			assertTrue(true);
+		} catch (Exception ex) {
+			fail("Unexpected exception: "+ex.getClass().getName()
+					+": "+ex.getMessage());
+		} finally {
+			outputDirectory.delete();
+		}
+	}
+}

--- a/org.jactr.tools/src/org/jactr/tools/tracer/sinks/trace/internal/TraceFileManager.java
+++ b/org.jactr.tools/src/org/jactr/tools/tracer/sinks/trace/internal/TraceFileManager.java
@@ -248,7 +248,7 @@ public class TraceFileManager
 
       return true;
     }
-    catch (Exception e)
+    catch (IOException e)
     {
       LOGGER.error("failed to flush ", e);
       cleanup();
@@ -284,7 +284,8 @@ public class TraceFileManager
               _recordWindow[1], _currentFile.getCanonicalPath()));
       }
 
-      output.flush();
+      if(output != null)
+    	  output.flush();
 
       // _gzipOutputStream.finish();
     }


### PR DESCRIPTION
but no events have been saved"
- NullPointerException is not thrown anymore
- NullPointerException is also not caught and logged anymore, should it
  be raised in the future, to be able to detect it more easily
