### PR TITLE
+ updating TraceFileManager constructor

### DIFF
--- a/org.jactr.tests/src/org/jactr/tools/tracer/sinks/trace/internal/TraceFileManagerTest.java
+++ b/org.jactr.tests/src/org/jactr/tools/tracer/sinks/trace/internal/TraceFileManagerTest.java
@@ -31,8 +31,7 @@ public class TraceFileManagerTest {
 		
 		File outputDirectory = File.createTempFile("output", "dir");
 		try {
-			TraceIndex index = new TraceIndex(outputDirectory);
-			TraceFileManager manager = new TraceFileManager(outputDirectory, index);
+			TraceFileManager manager = new TraceFileManager(outputDirectory);
 			manager.flush();
 			manager.record(event);
 			assertTrue(true);


### PR DESCRIPTION
the previously-used constructor was gone (compiler error ;-) )
